### PR TITLE
fix: reset detail scores button when no spam headers available

### DIFF
--- a/images/score_no.svg
+++ b/images/score_no.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Ebene_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#d3d3d3;}
+</style>
+<path class="st0" d="M8,0C3.6,0,0,3.6,0,8s3.6,8,8,8s8-3.6,8-8S12.4,0,8,0z M11.2,8.8H4.8c-0.5,0-0.8-0.4-0.8-0.8s0.4-0.8,0.8-0.8
+	h6.4c0.5,0,0.8,0.4,0.8,0.8S11.6,8.8,11.2,8.8z"/>
+</svg>

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -51,6 +51,7 @@ function getScores(headers) {
  * @returns {string} Path of Image
  */
 async function getImageSrc(score) {
+  if (score === null) return 'images/score_no.svg'
   const storage = await localStorage.get(['scoreIconLowerBounds', 'scoreIconUpperBounds'])
   const [lowerBounds, upperBounds] = getBounds(storage)
   if (score > upperBounds) return '/images/score_positive.svg'
@@ -77,6 +78,8 @@ async function onMessageDisplayed(tab, message) {
   // Message Score Button
   if (score === null) {
     messageButton.disable(idTab)
+    messageButton.setTitle({ tabId: idTab, title: 'No Spam Score'})
+    messageButton.setIcon({ path: await getImageSrc(null) })
   } else {
     messageButton.enable(idTab)
     messageButton.setTitle({ tabId: idTab, title: 'Spam Score: ' + score })


### PR DESCRIPTION
Fixes #60

Message score button gets set to a grey neutral Icon and "No Spam Score" if the message contains no spam headers additionally to being disabled.