### PR TITLE
feat: support X-Spam-Result header

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -69,6 +69,7 @@ export const SPAM_HEADER_REGEX =
  */
 export const SCORE_DETAILS_ARRAY = [
   'x-spamd-result',
+  'x-spam-result',
   'x-spam-report',
   'x-spamcheck',
   'x-spam-status',


### PR DESCRIPTION
Some mail servers such as Stalwart use `X-Spam-Result` by default.