### PR TITLE
Minimal bugfix for parseFloat truthiness mistake.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.6.0",
+  "version": "1.6.0.1-bugfix-sjh",
   "author": "Christian Zaenker",
   "default_locale": "en",
   "applications": {

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -121,7 +121,7 @@ async function saveScoreLower() {
     try {
       if (newLowerBounds > newUpperBounds) throw Error('Upper score cannot be lower than lower bounds')
       if (newLowerBounds < -10000) throw Error('Wrong score lower bounds')
-      localStorage.set({ scoreIconLowerBounds: newLowerBounds })
+      localStorage.set({ scoreIconLowerBounds: String(newLowerBounds) })
       saveScores(newLowerBounds, newUpperBounds)
     } catch (error) {
       // Restore previously saved bounds or fallback to defaults
@@ -141,7 +141,7 @@ async function saveScoreUpper() {
     try {
       if (newLowerBounds > newUpperBounds) throw Error('Upper score cannot be lower than lower bounds')
       if (newUpperBounds > 10000) throw Error('Wrong score upper bounds')
-      localStorage.set({ scoreIconUpperBounds: newUpperBounds })
+      localStorage.set({ scoreIconUpperBounds: String(newUpperBounds) })
       saveScores(newLowerBounds, newUpperBounds)
     } catch (error) {
       // Restore previously saved bounds or fallback to defaults


### PR DESCRIPTION
I recently discovered a frustrating bug while using Spam Scores...  I wanted to have any negative score shown with the green icon... but when I set "**Score icon ranges**" "**Score less than**"  to zero... the plugin seemed to suffer amnesia - and lose the configuration.

This seemed a straightforward bug when I noticed `src/options/options.js`:137

    const newLowerBounds = parseFloat(storage.scoreIconLowerBounds || DEFAULT_SCORE_LOWER_BOUNDS)

This doesn't make sense if `storage.scoreIconLowerBounds` is a number... with a value of 0 - as the truthiness of that value is false... whereas it'd need to be true to avoid it being replaced by the default value.  I think, when the above line was written, the expectation was that `storage.scoreIconLowerBounds` would be a string - and an empty string should have the default value substituted for it. I opted to fix the type of storage.scoreIconLowerBounds - by converting the numeric value to a string before setting the value maintained in local storage.

There's an analogous issue with `scoreIconUpperBounds` for which this pull request adopts a similar approach.

My intention is that this pull-request should be the minimum change required so icon boundary scores can be set to zero without them being silently reset to the default values.